### PR TITLE
Add group affinity

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -90,12 +90,12 @@ void
 usersim_clean_up_irql();
 
 USERSIM_API
-void
-usersim_set_affinity_and_priority_override(uint32_t processor_index);
+bool
+usersim_set_current_thread_priority(int priority, int* old_priority);
 
 USERSIM_API
-void
-usersim_clear_affinity_and_priority_override();
+bool
+usersim_set_current_thread_affinity(const GROUP_AFFINITY* new_affinity, GROUP_AFFINITY* old_affinity);
 
 #pragma endregion irqls
 

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -363,7 +363,7 @@ KeSetSystemAffinityThreadEx(KAFFINITY affinity)
     } else {
         bool result = usersim_set_current_thread_affinity(&new_affinity, &old_affinity);
         if (result) {
-            return (KAFFINITY)old_affinity.Mask;
+            return old_affinity.Mask;
         } else {
             return 0;
         }
@@ -392,7 +392,12 @@ KeSetSystemGroupAffinityThread(_In_ const PGROUP_AFFINITY Affinity, _Out_opt_ PG
 void
 KeRevertToUserGroupAffinityThread(PGROUP_AFFINITY PreviousAffinity)
 {
-    (void)usersim_set_current_thread_affinity(PreviousAffinity, nullptr);
+    bool result = usersim_set_current_thread_affinity(PreviousAffinity, nullptr);
+#if defined(NDEBUG)
+    UNREFERENCED_PARAMETER(result);
+#else
+    assert(result);
+#endif
 }
 
 PKTHREAD
@@ -654,10 +659,10 @@ class _usersim_emulated_dpc
 
                         l.unlock();
                         _usersim_dispatch_locks[i].lock();
-                        //_usersim_current_irql = DISPATCH_LEVEL;
+                        _usersim_current_irql = DISPATCH_LEVEL;
                         work_item->work_item_routine(work_item, context, parameter_1, parameter_2);
                         _usersim_dispatch_locks[i].unlock();
-                        //_usersim_current_irql = PASSIVE_LEVEL;
+                        _usersim_current_irql = PASSIVE_LEVEL;
                         l.lock();
                     }
                 }

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -151,6 +151,7 @@ usersim_set_current_thread_priority(int priority, int* old_priority)
  * @return true Success.
  * @return false Failure.
  */
+USERSIM_API
 bool
 usersim_set_current_thread_affinity(const GROUP_AFFINITY* new_affinity, GROUP_AFFINITY* old_affinity)
 {
@@ -194,7 +195,7 @@ _get_irql_thread_priority(KIRQL irql)
 inline BOOL
 _set_current_thread_priority_by_irql(KIRQL new_irql)
 {
-    if (new_irql > DISPATCH_LEVEL) {
+    if (new_irql >= DISPATCH_LEVEL) {
         return usersim_set_current_thread_priority(
             _get_irql_thread_priority(new_irql), &_usersim_thread_priority_before_raise_irql);
     } else {

--- a/src/platform.h
+++ b/src/platform.h
@@ -426,12 +426,6 @@ usersim_random_uint32();
 uint64_t
 usersim_query_time_since_boot(bool include_suspended_time);
 
-_Must_inspect_result_ bool
-usersim_set_current_thread_affinity(const GROUP_AFFINITY* new_affinity, GROUP_AFFINITY* old_affinity);
-
-void
-usersim_restore_current_thread_affinity(GROUP_AFFINITY* old_affinity);
-
 typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 
 /**

--- a/src/platform.h
+++ b/src/platform.h
@@ -426,11 +426,11 @@ usersim_random_uint32();
 uint64_t
 usersim_query_time_since_boot(bool include_suspended_time);
 
-_Must_inspect_result_ usersim_result_t
-usersim_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask);
+_Must_inspect_result_ bool
+usersim_set_current_thread_affinity(const GROUP_AFFINITY* new_affinity, GROUP_AFFINITY* old_affinity);
 
 void
-usersim_restore_current_thread_affinity(uintptr_t old_thread_affinity_mask);
+usersim_restore_current_thread_affinity(GROUP_AFFINITY* old_affinity);
 
 typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 

--- a/tests/ke_test.cpp
+++ b/tests/ke_test.cpp
@@ -177,11 +177,12 @@ TEST_CASE("threads", "[ke]")
 
     KAFFINITY new_affinity = ((ULONG_PTR)1 << processor_count) - 1;
     KAFFINITY old_affinity = KeSetSystemAffinityThreadEx(new_affinity);
-    REQUIRE(old_affinity != 0);
+    // No old affinity was set.
+    REQUIRE(old_affinity == 0);
 
     KeRevertToUserAffinityThreadEx(old_affinity);
 
-     for (ULONG i = 0; i < processor_count; i++) {
+    for (ULONG i = 0; i < processor_count; i++) {
         PROCESSOR_NUMBER processor_number = {};
         GROUP_AFFINITY old_group_affinity = {};
         GROUP_AFFINITY new_group_affinity = {};

--- a/tests/ke_test.cpp
+++ b/tests/ke_test.cpp
@@ -40,8 +40,6 @@ TEST_CASE("irql", "[ke]")
 
 TEST_CASE("irql_perf_override", "[ke]")
 {
-    usersim_set_affinity_and_priority_override(0);
-
     REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
 
     KIRQL old_irql;
@@ -65,8 +63,6 @@ TEST_CASE("irql_perf_override", "[ke]")
 
     KeLowerIrql(old_irql);
     REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
-
-    usersim_clear_affinity_and_priority_override();
 }
 
 TEST_CASE("KfRaiseIrql", "[ke]")


### PR DESCRIPTION
This pull request includes significant changes to the `usersim` API, primarily focusing on thread priority and affinity management. The updates aim to improve the efficiency and clarity of the codebase by replacing and refactoring several functions.

### Changes to thread priority and affinity management:

* [`inc/usersim/ke.h`](diffhunk://#diff-b8dcb37bfb713c012fcd5f680d7c8d09631115092cca187a2bb90707b9c8154eL93-R98): Replaced `usersim_set_affinity_and_priority_override` and `usersim_clear_affinity_and_priority_override` with `usersim_set_current_thread_priority` and `usersim_set_current_thread_affinity`.

* [`src/ke.cpp`](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL24-R31): Updated thread-local variables for better clarity and added detailed comments for new functions.

* [`src/ke.cpp`](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL113-R203): Refactored `usersim_set_current_thread_priority` and `usersim_set_current_thread_affinity` to cache values and avoid redundant operations.

* [`src/ke.cpp`](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL198-L204): Modified `KeRaiseIrql` and `KeLowerIrql` to use the new affinity and priority functions, removing the old override logic. [[1]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL198-L204) [[2]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL226-L232)

* [`src/ke.cpp`](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bR354-R369): Updated `KeSetSystemAffinityThreadEx` and `KeSetSystemGroupAffinityThread` to use the new affinity functions. [[1]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bR354-R369) [[2]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL359-R381)

### Removal of deprecated functions:

* [`src/ke.cpp`](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL372-L394): Removed the deprecated `usersim_get_current_thread_group_affinity` and associated logic.

* [`src/platform.h`](diffhunk://#diff-c2d906a1d52816e42e57c6e6c0ad9e0483b02f8df6cd2d03f6d23ebc748fce9fL429-L434): Removed the old thread affinity functions.

### Test updates:

* [`tests/ke_test.cpp`](diffhunk://#diff-afb8ded167839a6afd7a23e57a4b8611013e46c6de2f8522992e316bd13ba081L43-L44): Updated tests to reflect the removal of the old affinity and priority override functions. [[1]](diffhunk://#diff-afb8ded167839a6afd7a23e57a4b8611013e46c6de2f8522992e316bd13ba081L43-L44) [[2]](diffhunk://#diff-afb8ded167839a6afd7a23e57a4b8611013e46c6de2f8522992e316bd13ba081L68-L69)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for managing thread priorities and affinities, enhancing performance and efficiency.
  
- **Bug Fixes**
	- Improved error handling in processor information management and spin lock functions to ensure thread safety.

- **Tests**
	- Simplified test cases by removing outdated affinity and priority override calls, focusing on IRQL behavior. 

- **Chores**
	- Removed obsolete function declarations related to thread affinity management, streamlining the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->